### PR TITLE
qtmmlwidget bug fix

### DIFF
--- a/src/mml/qtmmlwidget.cpp
+++ b/src/mml/qtmmlwidget.cpp
@@ -6212,7 +6212,9 @@ const OperSpec *&OperSpecSearchResult::getForm(Mml::FormType f)
  */
 static const OperSpec *searchOperSpecData(const QString &name)
 {
-  const char *name_latin1 = name.toLatin1().data();
+  // keep a reference to the byte array, otherwise it is destroyed after this line and we are left with a pointer to garbage
+  QByteArray nameByteArray = name.toLatin1();
+  const char *name_latin1 = nameByteArray.data();
 
   // binary search
   // establish invariant g_oper_spec_data[begin].name < name < g_oper_spec_data[end].name
@@ -6267,7 +6269,9 @@ static OperSpecSearchResult _mmlFindOperSpec(const QStringList &name_list, Mml::
       if (spec == 0)
         continue;
 
-      const char *name_latin1 = name.toLatin1().data();
+      // keep a reference to the byte array, otherwise it is destroyed after this line and we are left with a pointer to garbage
+      QByteArray nameByteArray = name.toLatin1();
+      const char *name_latin1 = nameByteArray.data();
 
       // backtrack to the first instance of name
       while (spec > g_oper_spec_data && qstrcmp((spec - 1)->name, name_latin1) == 0)


### PR DESCRIPTION
  - str.toLatin1().data() returns a pointer to the data of the temporary object str.toLatin1()
  - the temporary is then destroyed, leaving a pointer to garbage
  - if the pointer is later dereferenced get segfault/undefined behaviour
  - fix this by keeping a reference to the object while the pointer is being used